### PR TITLE
Deal correctly with non-existing schemas

### DIFF
--- a/lib/frise/defaults_loader.rb
+++ b/lib/frise/defaults_loader.rb
@@ -56,12 +56,12 @@ module Frise
       end
 
       def merge_defaults(config, defaults_file, symbol_table = config)
-        defaults = Parser.parse(defaults_file, symbol_table)
+        defaults = Parser.parse(defaults_file, symbol_table) || {}
         merge_defaults_obj(config, defaults)
       end
 
       def merge_defaults_at(config, at_path, defaults_file, symbol_table = config)
-        defaults = Parser.parse(defaults_file, symbol_table)
+        defaults = Parser.parse(defaults_file, symbol_table) || {}
         merge_defaults_obj_at(config, at_path, defaults)
       end
     end

--- a/lib/frise/loader.rb
+++ b/lib/frise/loader.rb
@@ -16,7 +16,7 @@ module Frise
     end
 
     def load(config_file, exit_on_fail = true, symbol_table = {})
-      config = Parser.parse(config_file, symbol_table)
+      config = Parser.parse(config_file, symbol_table) || {}
       config_name = File.basename(config_file)
 
       @pre_loaders.each do |pre_loader|

--- a/lib/frise/parser.rb
+++ b/lib/frise/parser.rb
@@ -7,7 +7,7 @@ module Frise
   module Parser
     class << self
       def parse(file, symbol_table = nil)
-        return {} unless File.file? file
+        return nil unless File.file? file
         content = File.open(file).read
         content = Liquid::Template.parse(content).render symbol_table if symbol_table
         YAML.safe_load(content, [], [], true) || {}

--- a/lib/frise/validator.rb
+++ b/lib/frise/validator.rb
@@ -156,12 +156,12 @@ module Frise
     end
 
     def self.validate(config, schema_file, options = {})
-      schema = parse_symbols(Parser.parse(schema_file))
+      schema = parse_symbols(Parser.parse(schema_file) || { allow_unknown_keys: true })
       validate_obj(config, schema, options)
     end
 
     def self.validate_at(config, at_path, schema_file, options = {})
-      schema = parse_symbols(Parser.parse(schema_file))
+      schema = parse_symbols(Parser.parse(schema_file) || { allow_unknown_keys: true })
       at_path.reverse.each { |key| schema = { key => schema, :allow_unknown_keys => true } }
       validate_obj(config, schema, options)
     end

--- a/lib/frise/version.rb
+++ b/lib/frise/version.rb
@@ -1,3 +1,3 @@
 module Frise
-  VERSION = '0.1.0'.freeze
+  VERSION = '0.2.0.pre'.freeze
 end


### PR DESCRIPTION
While the default `Parser` behavior when the file doesn't exist is suitable for loading main config files and defaults, for schemas it would load an empty schema, which invalidates a config unless the config is also empty.

This PR changes `Parser` to return `nil` when a file doesn't exist so that user code can easily default to other structure.
