### PR TITLE
Process recursive inclusions as a DFS

### DIFF
--- a/lib/frise/defaults_loader.rb
+++ b/lib/frise/defaults_loader.rb
@@ -7,67 +7,75 @@ module Frise
   #
   # The merge_defaults and merge_defaults_at entrypoint methods provide ways to read files with
   # defaults and apply them to configuration objects.
-  module DefaultsLoader
-    class << self
-      SYMBOLS = %w[$all $optional].freeze
+  class DefaultsLoader
+    SYMBOLS = %w[$all $optional].freeze
 
-      def widened_class(obj)
-        class_name = obj.class.to_s
-        return 'Boolean' if %w[TrueClass FalseClass].include? class_name
-        return 'Integer' if %w[Fixnum Bignum].include? class_name
-        class_name
-      end
+    def initialize(include_sym: '$include', content_include_sym: '$content_include', schema_sym: '$schema')
+      @include_sym = include_sym
+      @content_include_sym = content_include_sym
+      @schema_sym = schema_sym
+    end
 
-      def merge_defaults_obj(config, defaults)
-        if defaults.nil?
-          config
+    def widened_class(obj)
+      class_name = obj.class.to_s
+      return 'String' if class_name == 'Hash' && !obj[@content_include_sym].nil?
+      return 'Boolean' if %w[TrueClass FalseClass].include? class_name
+      return 'Integer' if %w[Fixnum Bignum].include? class_name
+      class_name
+    end
 
-        elsif config.nil?
-          if defaults.class != Hash then defaults
-          elsif defaults['$optional'] then nil
-          else merge_defaults_obj({}, defaults)
-          end
+    def merge_defaults_obj(config, defaults)
+      config_class = widened_class(config)
+      defaults_class = widened_class(defaults)
 
-        elsif defaults.class == Array && config.class == Array
-          defaults + config
+      if defaults.nil?
+        config
 
-        elsif defaults.class == Hash && defaults['$all'] && config.class == Array
-          config.map { |elem| merge_defaults_obj(elem, defaults['$all']) }
-
-        elsif defaults.class == Hash && config.class == Hash
-          new_config = {}
-          (config.keys + defaults.keys).uniq.each do |key|
-            next if SYMBOLS.include?(key)
-            new_config[key] = config[key]
-            new_config[key] = merge_defaults_obj(new_config[key], defaults[key]) if defaults.key?(key)
-            new_config[key] = merge_defaults_obj(new_config[key], defaults['$all']) unless new_config[key].nil?
-            new_config.delete(key) if new_config[key].nil?
-          end
-          new_config
-
-        elsif widened_class(defaults) != widened_class(config)
-          raise "Cannot merge config #{config.inspect} (#{widened_class(config)}) " \
-            "with default #{defaults.inspect} (#{widened_class(defaults)})"
-
-        else
-          config
+      elsif config.nil?
+        if defaults_class != 'Hash' then defaults
+        elsif defaults['$optional'] then nil
+        else merge_defaults_obj({}, defaults)
         end
-      end
 
-      def merge_defaults_obj_at(config, at_path, defaults)
-        at_path.reverse.each { |key| defaults = { key => defaults } }
-        merge_defaults_obj(config, defaults)
-      end
+      elsif defaults_class == 'Array' && config_class == 'Array'
+        defaults + config
 
-      def merge_defaults(config, defaults_file, symbol_table = config)
-        defaults = Parser.parse(defaults_file, symbol_table) || {}
-        merge_defaults_obj(config, defaults)
-      end
+      elsif defaults_class == 'Hash' && defaults['$all'] && config_class == 'Array'
+        config.map { |elem| merge_defaults_obj(elem, defaults['$all']) }
 
-      def merge_defaults_at(config, at_path, defaults_file, symbol_table = config)
-        defaults = Parser.parse(defaults_file, symbol_table) || {}
-        merge_defaults_obj_at(config, at_path, defaults)
+      elsif defaults_class == 'Hash' && config_class == 'Hash'
+        new_config = {}
+        (config.keys + defaults.keys).uniq.each do |key|
+          next if SYMBOLS.include?(key)
+          new_config[key] = config[key]
+          new_config[key] = merge_defaults_obj(new_config[key], defaults[key]) if defaults.key?(key)
+          new_config[key] = merge_defaults_obj(new_config[key], defaults['$all']) unless new_config[key].nil?
+          new_config.delete(key) if new_config[key].nil?
+        end
+        new_config
+
+      elsif defaults_class != config_class
+        raise "Cannot merge config #{config.inspect} (#{widened_class(config)}) " \
+          "with default #{defaults.inspect} (#{widened_class(defaults)})"
+
+      else
+        config
       end
+    end
+
+    def merge_defaults_obj_at(config, at_path, defaults)
+      at_path.reverse.each { |key| defaults = { key => defaults } }
+      merge_defaults_obj(config, defaults)
+    end
+
+    def merge_defaults(config, defaults_file, symbol_table = config)
+      defaults = Parser.parse(defaults_file, symbol_table) || {}
+      merge_defaults_obj(config, defaults)
+    end
+
+    def merge_defaults_at(config, at_path, defaults_file, symbol_table = config)
+      defaults = Parser.parse(defaults_file, symbol_table) || {}
+      merge_defaults_obj_at(config, at_path, defaults)
     end
   end
 end

--- a/spec/frise/defaults_loader_spec.rb
+++ b/spec/frise/defaults_loader_spec.rb
@@ -7,7 +7,7 @@ include Frise
 RSpec.describe DefaultsLoader do
   it 'should merge correctly a file with plain default values' do
     conf = { 'a' => 45, 'str' => 'bcd' }
-    conf = DefaultsLoader.merge_defaults(conf, fixture_path('simple.yml'))
+    conf = DefaultsLoader.new.merge_defaults(conf, fixture_path('simple.yml'))
     expect(conf).to eq('a' => 45, 'str' => 'bcd', 'int' => 4, 'bool' => true)
   end
 
@@ -16,7 +16,7 @@ RSpec.describe DefaultsLoader do
       'arr' => ['elem2'],
       'obj' => { 'key2' => 'value02', 'key4' => 1 }
     }
-    conf = DefaultsLoader.merge_defaults(conf, fixture_path('all_types.yml'))
+    conf = DefaultsLoader.new.merge_defaults(conf, fixture_path('all_types.yml'))
     expect(conf['arr']).to eq %w[elem0 elem1 elem2]
     expect(conf['obj']).to eq(
       'key1' => 'value1',
@@ -28,15 +28,15 @@ RSpec.describe DefaultsLoader do
 
   it 'should merge files with Liquid templates if a symbol table is passed' do
     conf = { 'a' => 45, 'str' => 'bcd' }
-    conf = DefaultsLoader.merge_defaults(conf,
-                                         fixture_path('simple_liquid.yml'),
-                                         'var1' => 'REPLACED', 'var2' => 1)
+    conf = DefaultsLoader.new.merge_defaults(conf,
+                                             fixture_path('simple_liquid.yml'),
+                                             'var1' => 'REPLACED', 'var2' => 1)
     expect(conf).to eq('a' => 45, 'str' => 'bcd', 'int' => 1, 'bool' => true)
   end
 
   it 'should interpret the $all key in a default hash or array' do
     conf = { 'obj1' => {}, 'arr' => [] }
-    conf = DefaultsLoader.merge_defaults(conf, fixture_path('_defaults/all_specials.yml'))
+    conf = DefaultsLoader.new.merge_defaults(conf, fixture_path('_defaults/all_specials.yml'))
     expect(conf['obj1']).to eq({})
     expect(conf['arr']).to eq([])
 
@@ -52,7 +52,7 @@ RSpec.describe DefaultsLoader do
         { 'j' => 3, 'active' => false }
       ]
     }
-    conf = DefaultsLoader.merge_defaults(conf, fixture_path('_defaults/all_specials.yml'))
+    conf = DefaultsLoader.new.merge_defaults(conf, fixture_path('_defaults/all_specials.yml'))
     expect(conf['obj1']).to eq(
       'key1' => { 'i' => 1, 'enabled' => true },
       'key2' => { 'i' => 2, 'enabled' => true },
@@ -68,17 +68,17 @@ RSpec.describe DefaultsLoader do
   end
 
   it 'should interpret the $optional key in a default hash' do
-    conf = DefaultsLoader.merge_defaults({}, fixture_path('_defaults/all_specials.yml'))
+    conf = DefaultsLoader.new.merge_defaults({}, fixture_path('_defaults/all_specials.yml'))
     expect(conf['obj2']).to eq nil
 
     conf = { 'obj2' => {} }
-    conf = DefaultsLoader.merge_defaults(conf, fixture_path('_defaults/all_specials.yml'))
+    conf = DefaultsLoader.new.merge_defaults(conf, fixture_path('_defaults/all_specials.yml'))
     expect(conf['obj2']).to eq('nest1' => { 'nest2' => 'val' })
   end
 
   it 'should merge correctly a file at a given path' do
     conf = { 'a' => 45, 'str' => 'bcd' }
-    conf = DefaultsLoader.merge_defaults_at(conf, %w[new path], fixture_path('simple.yml'))
+    conf = DefaultsLoader.new.merge_defaults_at(conf, %w[new path], fixture_path('simple.yml'))
     expect(conf).to eq(
       'a' => 45,
       'str' => 'bcd',
@@ -90,11 +90,26 @@ RSpec.describe DefaultsLoader do
 
   it 'should raise an error when trying to merge defaults with different values' do
     conf = { 'int' => 'not_an_int' }
-    expect { DefaultsLoader.merge_defaults(conf, fixture_path('simple.yml')) }
+    expect { DefaultsLoader.new.merge_defaults(conf, fixture_path('simple.yml')) }
       .to raise_error 'Cannot merge config "not_an_int" (String) with default 4 (Integer)'
 
     conf = { 'int' => true }
-    expect { DefaultsLoader.merge_defaults(conf, fixture_path('simple.yml')) }
+    expect { DefaultsLoader.new.merge_defaults(conf, fixture_path('simple.yml')) }
       .to raise_error 'Cannot merge config true (Boolean) with default 4 (Integer)'
+  end
+
+  it 'should treat $content_include directives as string values' do
+    conf = { 'str' => { '$content_include' => ['str.txt'] } }
+    conf = DefaultsLoader.new.merge_defaults(conf, fixture_path('simple.yml'))
+    expect(conf).to eq(
+      'str' => { '$content_include' => ['str.txt'] },
+      'int' => 4,
+      'bool' => true
+    )
+
+    conf = { '$content_include' => ['str.txt'] }
+    expect { DefaultsLoader.new.merge_defaults(conf, fixture_path('simple.yml')) }
+      .to raise_error 'Cannot merge config {"$content_include"=>["str.txt"]} (String) ' \
+          'with default {"str"=>"abc", "int"=>4, "bool"=>true} (Hash)'
   end
 end


### PR DESCRIPTION
Makes `$content_include`s be treated as strings when merging defaults and process them with a DFS tree traversal. A config like:

```yaml
# a.yml
$include: ['b.yml', 'c.yml']

# b.yml
$include: ['b2.yml']

# b2.yml
# some configs here
```

Is processed in the following order:
- a.yml
- b.yml
- b2.yml
- c.yml
